### PR TITLE
baseparse: always update the input pts if available from upstream

### DIFF
--- a/subprojects/gstreamer/libs/gst/base/gstbaseparse.c
+++ b/subprojects/gstreamer/libs/gst/base/gstbaseparse.c
@@ -3263,9 +3263,10 @@ gst_base_parse_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
      * but interpolate in between */
     pts = gst_adapter_prev_pts (parse->priv->adapter, NULL);
     dts = gst_adapter_prev_dts (parse->priv->adapter, NULL);
-    if (GST_CLOCK_TIME_IS_VALID (pts) && (parse->priv->prev_pts != pts)) {
+    if (GST_CLOCK_TIME_IS_VALID (pts)) {
+      if (parse->priv->prev_pts != pts)
+        updated_prev_pts = TRUE;
       parse->priv->prev_pts = parse->priv->next_pts = pts;
-      updated_prev_pts = TRUE;
     }
 
     if (GST_CLOCK_TIME_IS_VALID (dts) && (parse->priv->prev_dts != dts)) {


### PR DESCRIPTION
We were not which could lead to output buffers having a pts of NONE even if all the input ts were entirely coherent.  This meant that certain muxers would reject the buffer without a pts and fail.

reference:
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/649