### PR TITLE
gtkbasesink: Fix widget leak

### DIFF
--- a/subprojects/gst-plugins-good/ext/gtk/gstgtkbasesink.c
+++ b/subprojects/gst-plugins-good/ext/gtk/gstgtkbasesink.c
@@ -230,7 +230,8 @@ gst_gtk_base_sink_get_widget (GstGtkBaseSink * gtk_sink)
 
   /* Take the floating ref, other wise the destruction of the container will
    * make this widget disappear possibly before we are done. */
-  gst_object_ref_sink (gtk_sink->widget);
+  g_object_ref_sink (gtk_sink->widget);
+
   gtk_sink->widget_destroy_id = g_signal_connect (gtk_sink->widget, "destroy",
       G_CALLBACK (widget_destroy_cb), gtk_sink);
 
@@ -339,6 +340,7 @@ gst_gtk_base_sink_navigation_send_event (GstNavigation * navigation,
     gtk_gst_base_widget_display_size_to_stream_size (widget,
         x, y, &stream_x, &stream_y);
     gst_navigation_event_set_coordinates (event, stream_x, stream_y);
+    g_object_unref (widget);
   }
 
   pad = gst_pad_get_peer (GST_VIDEO_SINK_PAD (sink));
@@ -370,8 +372,10 @@ gst_gtk_base_sink_start_on_main (GstBaseSink * bsink)
   GstGtkBaseSink *gst_sink = GST_GTK_BASE_SINK (bsink);
   GstGtkBaseSinkClass *klass = GST_GTK_BASE_SINK_GET_CLASS (bsink);
   GtkWidget *toplevel;
+  GtkGstBaseWidget *widget;
 
-  if (gst_gtk_base_sink_get_widget (gst_sink) == NULL) {
+  widget = gst_gtk_base_sink_get_widget (gst_sink);
+  if (!widget) {
     GST_ERROR_OBJECT (bsink, "Could not ensure GTK initialization.");
     return FALSE;
   }
@@ -392,6 +396,8 @@ gst_gtk_base_sink_start_on_main (GstBaseSink * bsink)
     gst_sink->window_destroy_id = g_signal_connect (gst_sink->window, "destroy",
         G_CALLBACK (window_destroy_cb), gst_sink);
   }
+
+  g_object_unref (widget);
 
   return TRUE;
 }


### PR DESCRIPTION
gst_gtk_base_sink_get_widget() will increase refcount and it should be released after use

Fixing regression introduced by the commit
941c0e81ddf5c0ad6a9fac59b1d6bf7723025434